### PR TITLE
feat: FlexibleTime type for handling multiple date formats in OPDS feeds

### DIFF
--- a/opds/models.go
+++ b/opds/models.go
@@ -1,18 +1,76 @@
 package opds
 
 import (
+	"encoding/xml"
+	"strings"
 	"time"
 )
 
+// FlexibleTime handles multiple time formats commonly found in OPDS feeds
+type FlexibleTime struct {
+	time.Time
+}
+
+// UnmarshalXML implements xml.Unmarshaler to handle multiple date formats
+func (ft *FlexibleTime) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	var v string
+	if err := d.DecodeElement(&v, &start); err != nil {
+		return err
+	}
+
+	// Remove any extra whitespace
+	v = strings.TrimSpace(v)
+	if v == "" {
+		ft.Time = time.Time{}
+		return nil
+	}
+
+	// Try different time formats commonly used in OPDS feeds
+	formats := []string{
+		time.RFC3339,           // 2006-01-02T15:04:05Z07:00
+		time.RFC3339Nano,       // 2006-01-02T15:04:05.999999999Z07:00
+		"2006-01-02T15:04:05Z", // Without timezone offset
+		"2006-01-02T15:04:05",  // Without timezone
+		"2006-01-02",           // Date only
+	}
+
+	for _, format := range formats {
+		if t, err := time.Parse(format, v); err == nil {
+			ft.Time = t
+			return nil
+		}
+	}
+
+	// If none of the formats work, try to parse just the date part
+	if len(v) >= 10 {
+		if t, err := time.Parse("2006-01-02", v[:10]); err == nil {
+			ft.Time = t
+			return nil
+		}
+	}
+
+	// Return a zero time if we can't parse it
+	ft.Time = time.Time{}
+	return nil
+}
+
+// MarshalXML implements xml.Marshaler to output in RFC3339 format
+func (ft FlexibleTime) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	if ft.Time.IsZero() {
+		return nil
+	}
+	return e.EncodeElement(ft.Time.Format(time.RFC3339), start)
+}
+
 // Feed root element for acquisition or navigation feed
 type Feed struct {
-	ID           string    `xml:"id"`
-	Title        string    `xml:"title"`
-	Updated      time.Time `xml:"updated"`
-	Entries      []Entry   `xml:"entry"`
-	Links        []Link    `xml:"link"`
-	TotalResults int       `xml:"totalResults"`
-	ItemsPerPage int       `xml:"itemsPerPage"`
+	ID           string       `xml:"id"`
+	Title        string       `xml:"title"`
+	Updated      FlexibleTime `xml:"updated"`
+	Entries      []Entry      `xml:"entry"`
+	Links        []Link       `xml:"link"`
+	TotalResults int          `xml:"totalResults"`
+	ItemsPerPage int          `xml:"itemsPerPage"`
 }
 
 // Link link to different resources
@@ -35,21 +93,21 @@ type Author struct {
 
 // Entry an atom entry in the feed
 type Entry struct {
-	Title      string     `xml:"title"`
-	ID         string     `xml:"id"`
-	Identifier string     `xml:"identifier"`
-	Updated    *time.Time `xml:"updated"`
-	Rights     string     `xml:"rights"`
-	Publisher  string     `xml:"publisher"`
-	Author     []Author   `xml:"author,omitempty"`
-	Language   string     `xml:"language"`
-	Issued     string     `xml:"issued"` // Check for format
-	Published  *time.Time `xml:"published"`
-	Category   []Category `xml:"category,omitempty"`
-	Links      []Link     `xml:"link,omitempty"`
-	Summary    Content    `xml:"summary"`
-	Content    Content    `xml:"content"`
-	Series     []Serie    `xml:"Series"`
+	Title      string        `xml:"title"`
+	ID         string        `xml:"id"`
+	Identifier string        `xml:"identifier"`
+	Updated    *FlexibleTime `xml:"updated"`
+	Rights     string        `xml:"rights"`
+	Publisher  string        `xml:"publisher"`
+	Author     []Author      `xml:"author,omitempty"`
+	Language   string        `xml:"language"`
+	Issued     string        `xml:"issued"` // Check for format
+	Published  *FlexibleTime `xml:"published"`
+	Category   []Category    `xml:"category,omitempty"`
+	Links      []Link        `xml:"link,omitempty"`
+	Summary    Content       `xml:"summary"`
+	Content    Content       `xml:"content"`
+	Series     []Serie       `xml:"Series"`
 }
 
 // Content content tag in an entry, the type will be html or text

--- a/opds/models_test.go
+++ b/opds/models_test.go
@@ -1,0 +1,92 @@
+package opds
+
+import (
+	"encoding/xml"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestFlexibleTimeUnmarshal(t *testing.T) {
+	tests := []struct {
+		name     string
+		xmlData  string
+		expected string
+	}{
+		{
+			name:     "RFC3339 format",
+			xmlData:  `<wrapper><published>2006-01-02T15:04:05Z</published></wrapper>`,
+			expected: "2006-01-02T15:04:05Z",
+		},
+		{
+			name:     "Date only format",
+			xmlData:  `<wrapper><published>2006-07-18</published></wrapper>`,
+			expected: "2006-07-18T00:00:00Z",
+		},
+		{
+			name:     "Date with time no timezone",
+			xmlData:  `<wrapper><published>2006-01-02T15:04:05</published></wrapper>`,
+			expected: "2006-01-02T15:04:05Z",
+		},
+		{
+			name:     "Empty published date",
+			xmlData:  `<wrapper><published></published></wrapper>`,
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var result struct {
+				Published *FlexibleTime `xml:"published"`
+			}
+
+			err := xml.NewDecoder(strings.NewReader(tt.xmlData)).Decode(&result)
+			if err != nil {
+				t.Fatalf("Failed to unmarshal XML: %v", err)
+			}
+
+			if tt.expected == "" {
+				if result.Published != nil && !result.Published.Time.IsZero() {
+					t.Errorf("Expected nil or zero time, got %v", result.Published.Time)
+				}
+				return
+			}
+
+			if result.Published == nil {
+				t.Errorf("Expected non-nil published time")
+				return
+			}
+
+			actual := result.Published.Time.UTC().Format(time.RFC3339)
+			if actual != tt.expected {
+				t.Errorf("Expected %s, got %s", tt.expected, actual)
+			}
+		})
+	}
+}
+
+func TestEntryWithDateOnlyPublished(t *testing.T) {
+	xmlData := `<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns="http://www.w3.org/2005/Atom">
+	<title>Test Book</title>
+	<id>test-id</id>
+	<published>2006-07-18</published>
+</entry>`
+
+	var entry Entry
+	err := xml.NewDecoder(strings.NewReader(xmlData)).Decode(&entry)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal entry: %v", err)
+	}
+
+	if entry.Published == nil {
+		t.Error("Expected published date to be parsed")
+		return
+	}
+
+	expected := time.Date(2006, 7, 18, 0, 0, 0, 0, time.UTC)
+	if !entry.Published.Time.Equal(expected) {
+		t.Errorf("Expected %v, got %v", expected, entry.Published.Time)
+	}
+}


### PR DESCRIPTION
Testing with Booklore's OPDS feed revealed that they use just a date like "YYYY-MM-DD" which the native XML decoder doesn't support for the `time.Time` struct