### PR TITLE
fix: remove hardcoded return value in DetectDevice

### DIFF
--- a/internal/device/device.go
+++ b/internal/device/device.go
@@ -17,7 +17,6 @@ const (
 
 // DetectDevice determines the device type based on the user agent string
 func DetectDevice(userAgent string) DeviceType {
-	return DeviceKobo
 	if strings.Contains(userAgent, "Kobo") {
 		return DeviceKobo
 	}


### PR DESCRIPTION
This was overlooked as I was using it for testing conversions by spoofing different device types.

Fixes #124 